### PR TITLE
Travis CI: Lint Python code for syntax errors and warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 before_install:
   - pip install --upgrade pip
   - python setup.py install
-  - pip install coverage[toml] coveralls IPython nbconvert pytest-cov
+  - pip install coverage[toml] coveralls flake8 IPython nbconvert pytest-cov
 before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 script: pytest --cov-report term --cov
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
+os: linux
+dist: focal
 language: python
 python:
- - 3.7
-script: pytest --cov-report term --cov
+  - 3.7
 before_install:
- - "pip install -U pip"
- - "python setup.py install"
- - "pip install pytest-cov"
- - "pip install coverage[toml]"
- - "pip install coveralls"
- - "pip install nbconvert"
- - "pip install IPython"
-
-after_success:
- - "coveralls"
+  - pip install --upgrade pip
+  - python setup.py install
+  - pip install coverage[toml] coveralls IPython nbconvert pytest-cov
+before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+script: pytest --cov-report term --cov
+after_success: coveralls

--- a/handcalcs/handcalcs.py
+++ b/handcalcs/handcalcs.py
@@ -1574,15 +1574,15 @@ def swap_frac_divs(code: deque) -> deque:
     close_bracket_token = False
     for index, item in enumerate(code):
         next_idx = min(index + 1, length - 1)
-        if code[next_idx] is "/" and isinstance(item, deque):
+        if code[next_idx] == "/" and isinstance(item, deque):
             new_item = f"{ops}{a}"
             swapped_deque.append(new_item)
             swapped_deque.append(swap_frac_divs(item))  # recursion!
-        elif code[next_idx] is "/" and not isinstance(item, deque):
+        elif code[next_idx] == "/" and not isinstance(item, deque):
             new_item = f"{ops}{a}"
             swapped_deque.append(new_item)
             swapped_deque.append(item)
-        elif item is "/":
+        elif item == "/":
             swapped_deque.append(f"{b}{a}")
             close_bracket_token = True
         elif close_bracket_token:
@@ -1670,9 +1670,9 @@ def swap_py_operators(pycode_as_deque: deque) -> deque:
             new_item = swap_py_operators(item)  # recursion!
             swapped_deque.append(new_item)
         else:
-            if item is "*":
+            if item == "*":
                 swapped_deque.append("\\cdot")
-            elif item is "%":
+            elif item == "%":
                 swapped_deque.append("\\bmod")
             else:
                 swapped_deque.append(item)

--- a/handcalcs/install_templates.py
+++ b/handcalcs/install_templates.py
@@ -3,7 +3,7 @@ import pathlib
 import shutil
 import nbconvert
 
-__all__ = ["install_latex_template", "install_html_template"]
+__all__ = ["install_latex", "install_html"]
 
 def install_latex(swap_in: str = "", swap_out: str = "article.tplx", restore: bool = False) -> None:
     """


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> "/" is "/"
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```
[flake8](http://flake8.pycqa.org) testing of https://github.com/connorferster/handcalcs on Python 3.9.0rc1+

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./handcalcs/handcalcs.py:1577:12: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
        if code[next_idx] is "/" and isinstance(item, deque):
           ^
./handcalcs/handcalcs.py:1581:14: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
        elif code[next_idx] is "/" and not isinstance(item, deque):
             ^
./handcalcs/handcalcs.py:1585:14: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
        elif item is "/":
             ^
./handcalcs/handcalcs.py:1673:16: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
            if item is "*":
               ^
./handcalcs/handcalcs.py:1675:18: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
            elif item is "%":
                 ^
./handcalcs/install_templates.py:6:1: F822 undefined name 'install_latex_template' in __all__
__all__ = ["install_latex_template", "install_html_template"]
^
./handcalcs/install_templates.py:6:1: F822 undefined name 'install_html_template' in __all__
__all__ = ["install_latex_template", "install_html_template"]
^
5     F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
2     F822 undefined name 'install_latex_template' in __all__
7
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.