### PR TITLE
Use `innerscope` instead of `return locals()` in decorated function.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ dist: focal
 language: python
 python:
   - 3.7
+  - 3.8
+  - "3.9-dev"
 before_install:
   - pip install --upgrade pip
   - python setup.py install
-  - pip install coverage[toml] coveralls flake8 IPython nbconvert pytest-cov
+  - pip install coverage[toml] coveralls flake8 IPython nbconvert pytest-cov innerscope
 before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 script: pytest --cov-report term --cov
 after_success: coveralls

--- a/Examples/streamlit_example.py
+++ b/Examples/streamlit_example.py
@@ -6,7 +6,6 @@ import streamlit as st
 def quadratic(a,b,c):
     x_1 = (-b + sqrt(b**2 - 4*a*c)) / (2*a)
     x_2 = (-b - sqrt(b**2 - 4*a*c)) / (2*a)
-    return locals()
 
 a = st.slider("Value for a:", 1,5, 5)
 b = st.slider("Value for b:", -10, 10, -5)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Start by importing the `@handcalc()` decorator:
 from handcalcs.decorator import handcalc
 ```
 
-Then, write your function. Your function MUST `return locals()`:
+Then, write your function.
 
 ```python
 @handcalc()
@@ -119,7 +119,6 @@ def my_calc(x, y, z):
   a = 2*x / y
   b = 3*a
   c = (a + b) / z
-  return locals()
 ```
 
 #### `@handcalc(left: str = "", right: str = "", jupyter_display: bool = False)`
@@ -129,7 +128,7 @@ Returns a tuple consisting of `(latex_code: str, locals: dict)`, where `locals` 
 * `left` and `right` are strings that can precede and follow the encoded Latex string, such as `\\[` and `\\]` or `$` and `$`
 * `jupyter_display`, when True, will return only the `locals` dictionary and instead will display the encoded Latex string rendering with `display(Latex(latex_code))` from `IPython.display`. Will return an error if not used within 
 
-In your decorated function, everything between `def my_calc(...)` and `return locals()` is now like the code in a Jupyter cell, except it's a standard Python function.
+In your decorated function, everything between `def my_calc(...)` and a return statement (if any) is now like the code in a Jupyter cell, except it's a standard Python function.
 
 Used in this way, you can use `@handcalc()` to dynamically generate Latex code for display in Jupyter and non-Jupypter Python environments (e.g. streamlit). 
 

--- a/eqn_lib.py
+++ b/eqn_lib.py
@@ -7,4 +7,3 @@ def NBCC2015LC(DL: float = 0, SDL: float = 0, SL: float = 0, LL: float = 0, WL: 
     LC2b = 1.25*DL + 1.5*LL + 0.5*SL
     LC3a = 1.25*DL + 1.5*SL
     LC3b = 1.25*DL + 1.5*SL + 0.5*LL
-    return locals()

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ VERSION = '0.2.0'
 # What packages are required for this module to be executed?
 REQUIRED = [
     'pyparsing',
+    'innerscope >= 0.2.0',
     # 'requests', 'maya', 'records',
 ]
 

--- a/test_handcalcs/test_handcalcs_file.py
+++ b/test_handcalcs/test_handcalcs_file.py
@@ -78,13 +78,11 @@ def remove_imports_defs_and_globals(source: str):
 def func_1(x, y):
     a = 2 * x
     b = 3 * a + y
-    return locals()
 
 @handcalc(jupyter_display=True)
 def func_2(x, y):
     a = 2 * x
     b = 3 * a + y
-    return locals()
 
 @handcalc(jupyter_display=True)
 def error_func(x, y):
@@ -93,7 +91,6 @@ def error_func(x, y):
     """
     a = 2 * x
     b = 3 * a + y
-    return b  # Must return locals()
 
 
 cell_1_source = remove_imports_defs_and_globals(inspect.getsource(cell_1))
@@ -235,7 +232,7 @@ def test_error_cell():
 
 def test_error_func():
     with pytest.raises(ValueError):
-        error_func(4, 5)
+        error_func(4, 5)  # Unable to handle the docstring
 
 
 def test_add_result_values_to_lines_error():

--- a/test_handcalcs/test_handcalcs_file.py
+++ b/test_handcalcs/test_handcalcs_file.py
@@ -83,6 +83,7 @@ def func_1(x, y):
 def func_2(x, y):
     a = 2 * x
     b = 3 * a + y
+    return locals()  # not necessary, but allowed
 
 @handcalc(jupyter_display=True)
 def error_func(x, y):


### PR DESCRIPTION
Hey hey!  So, cool library.  Very slick.  However, the loud, repeated warnings such as "Your function MUST `return locals()`" is a bit jarring.  I think it would provide a nicer user experience (and a much nicer experience reading docs and examples) if returning locals wasn't required.

Enter [`innerscope`](https://github.com/eriknw/innerscope).  It does just this.  It exposes locals.

Note that `innerscope` does not yet support Python 3.7, but I can add Python 3.7 support if y'all are interested.  Although it's kind of a silly package, I think it does what it does pretty well.  It has 100% code and branch coverage, and all functions and methods have docstrings with examples.  Heh, maybe I took things too far ;)

I haven't updated your docs yet.  I can.

Also, I added Python 3.8 and 3.9-dev to your CI tests.

Finally, this PR is backwards compatible.  It's no problem if a function returns locals.  I should add a test to prove this.