### PR TITLE
Fix single line docstring parsing error

### DIFF
--- a/handcalcs/decorator.py
+++ b/handcalcs/decorator.py
@@ -58,7 +58,7 @@ def _func_source_to_cell(source: str):
             continue
         elif (not doc_string
             and line.lstrip(' \t').startswith('"""')
-            and not line.endswith('"""')):
+            and not line.rstrip().endswith('"""')):
             doc_string = True
             continue
         elif (doc_string

--- a/handcalcs/decorator.py
+++ b/handcalcs/decorator.py
@@ -53,12 +53,12 @@ def _func_source_to_cell(source: str):
     for line in source_lines:
         if (not doc_string
             and line.lstrip(' \t').startswith('"""')
-            and line.lstrip().rstrip().endswith('"""',3)):
+            and line.lstrip(' \t').rstrip().endswith('"""',3)):
             doc_string = False
             continue
         elif (not doc_string
             and line.lstrip(' \t').startswith('"""')
-            and not line.lstrip().rstrip().endswith('"""',3)):
+            and not line.lstrip(' \t').rstrip().endswith('"""',3)):
             doc_string = True
             continue
         elif doc_string and '"""' in line:

--- a/handcalcs/decorator.py
+++ b/handcalcs/decorator.py
@@ -53,16 +53,15 @@ def _func_source_to_cell(source: str):
     for line in source_lines:
         if (not doc_string
             and line.lstrip(' \t').startswith('"""')
-            and line.rstrip().endswith('"""')):
+            and line.lstrip().rstrip().endswith('"""',3)):
             doc_string = False
             continue
         elif (not doc_string
             and line.lstrip(' \t').startswith('"""')
-            and not line.rstrip().endswith('"""')):
+            and not line.lstrip().rstrip().endswith('"""',3)):
             doc_string = True
             continue
-        elif (doc_string
-            and line.rstrip().endswith('"""')):
+        elif doc_string and '"""' in line:
             doc_string = False
             continue
         if (

--- a/handcalcs/decorator.py
+++ b/handcalcs/decorator.py
@@ -51,13 +51,20 @@ def _func_source_to_cell(source: str):
     acc = []
     doc_string = False
     for line in source_lines:
-        if not doc_string and '"""' in line:
-            doc_string = True
-            continue
-        elif doc_string and '"""' in line:
+        if (not doc_string
+            and line.lstrip(' \t').startswith('"""')
+            and line.rstrip().endswith('"""')):
             doc_string = False
             continue
-        
+        elif (not doc_string
+            and line.lstrip(' \t').startswith('"""')
+            and not line.endswith('"""')):
+            doc_string = True
+            continue
+        elif (doc_string
+            and line.rstrip().endswith('"""')):
+            doc_string = False
+            continue
         if (
             "def" not in line
             and not doc_string

--- a/test_handcalcs/test_handcalcs_file.py
+++ b/test_handcalcs/test_handcalcs_file.py
@@ -93,13 +93,18 @@ def remove_imports_defs_and_globals(source: str):
     acc = []
     doc_string = False
     for line in source_lines:
-        if not doc_string and '"""' in line:
+        if (not doc_string
+            and line.lstrip(' \t').startswith('"""')
+            and line.lstrip(' \t').rstrip().endswith('"""',3)):
+            doc_string = False
+            continue
+        elif (not doc_string
+            and line.lstrip(' \t').startswith('"""')
+            and not line.lstrip(' \t').rstrip().endswith('"""',3)):
             doc_string = True
             continue
         elif doc_string and '"""' in line:
             doc_string = False
-            continue
-        elif doc_string:
             continue
         if (
             "def" not in line
@@ -111,7 +116,6 @@ def remove_imports_defs_and_globals(source: str):
         ):
             acc.append(line)
     return "\n".join(acc)
-
 
 @handcalc()
 def func_1(x, y):
@@ -130,6 +134,12 @@ def func_2(x, y):
     b = 3 * a + y
     return locals()  # not necessary, but allowed
 
+@handcalc(jupyter_display=True)
+def func_3(x, y):
+    """My single line docstring"""
+    a = 2 * x
+    b = 3 * a + y
+    return locals()  # not necessary, but allowed
 
 line_args = {"override": "", "precision": ""}
 line_args_params = {"override": "params", "precision": ""}
@@ -261,6 +271,8 @@ def test_handcalc():
 def test_handcalc2():
     assert func_2(4, 5) == {"x": 4, "y": 5, "a": 8, "b": 29}
 
+def test_handcalcs3():
+    assert func_3(4, 5) == {"x": 4, "y": 5, "a": 8, "b": 29}
 
 # Test template.py
 


### PR DESCRIPTION
**What it fixes**
Related to Issue #66 this allows a single line doc-string to be used when using the python decorator.
I read online that Regex needs to be compiled first, which can make it slower than the python string functions I adopted.

**Limitations**
I decided to keep it simple for my first pull request, in case the maintainer wants to style the code differently.
- did not integrate multi-line definition statements #64 
- did not integrate docstrings with single quotes `'''`
- did not run the test-suite, but did some manual testing below. I might learn how to do it myself for the next PR.

**Testing conducted**
- created a new environment in conda and `pip install streamlit`
- Forked and cloned the `handcalcs` repo
- `python setup.py install --user` inside the cloned handcalcs directory. **see bottom as the installation didn't behave quite right**
- Run the following script including writing 2 identical functions except with a single vs. double line doc-string

```python
import streamlit as st
import handcalcs

@handcalcs.handcalc(override="long")
def addition1(val1,val2):
    """doc string doc string 2"""
    c = val1/val2
    return c

@handcalcs.handcalc(override="long")
def addition2(val1,val2):
    """doc string
    doc string 2"""
    c = val1/val2
    return c

latex1, vals1 = addition1(1,2)
st.write("Single Line docstring")
st.latex(latex1)

latex2, vals2 = addition2(a,b)
st.write("Multi Line docstring")
st.latex(latex2)
```

**Output**
![image](https://user-images.githubusercontent.com/58811856/100084710-33488300-2e9f-11eb-962f-1dcafd72a6c5.png)

**Issues installing using `python setup.py install`**
When running the above script `additionX(val1,val2)` was generating the following console outputs (which I usually don't get when I pip install handcalcs). The latex appears to still work though.
```
No match:  val1
div:  /
No match:  val2
Return:  [True, False, True, False]
op:  =
No match:  val1
div:  /
No match:  val2
Return:  [True, False, True, False]
```