### PR TITLE
Round SymPy expressions and nested elements

### DIFF
--- a/handcalcs/handcalcs.py
+++ b/handcalcs/handcalcs.py
@@ -1601,9 +1601,17 @@ def round_sympy(elem: Any, precision: int) -> Any:
     Returns the Sympy expression 'elem' rounded to 'precision'
     """
     from sympy import Float
-    rounded = elem.xreplace(
-        {n: round(n, precision) for n in elem.atoms(Float)}
-    )
+    rule = {}
+    for n in elem.atoms(Float):
+        if test_for_small_float(float(n), precision):
+            # Equivalent to:
+            # > rule[n] = round(n, precision - int(math.log10(abs(n))) + 1)
+            rule[n] = float(
+                swap_scientific_notation_float([float(n)], precision)[0]
+            )
+        else:
+            rule[n] = round(n, precision)
+    rounded = elem.xreplace(rule)
     if hasattr(elem, 'units') and not hasattr(rounded, 'units'):
         # Add back pint units lost during rounding.
         rounded = rounded * elem.units

--- a/test_handcalcs/test_pint.py
+++ b/test_handcalcs/test_pint.py
@@ -4,13 +4,13 @@ from handcalcs.handcalcs import (
     CalcLine, round_and_render_line_objects_to_latex
 )
 
+ureg = pint.UnitRegistry(auto_reduce_dimensions=True)
+ureg.default_format = '~'
+ft = ureg.ft
+kip = ureg.kip
+
 
 def test_pint_rounding():
-    ureg = pint.UnitRegistry(auto_reduce_dimensions=True)
-    ureg.default_format = '~'
-    ft = ureg.ft
-    kip = ureg.kip
-
     L = (1.23456789 * kip)
     d = (2 * ft)
     M = L * d
@@ -26,3 +26,16 @@ def test_pint_rounding():
     assert round_and_render_line_objects_to_latex(
         CalcLine([M], '', ''), precision=2, dec_sep='.'
     ).latex == '2.47\\ \\mathrm{ft} \\cdot \\mathrm{kip}'
+
+
+def test_pint_with_sympy():
+    import sympy
+    pint.quantity._Quantity._sympy_ = lambda s: sympy.sympify(f'({s.m})*{s.u}')
+    pint.quantity._Quantity._repr_latex_ = lambda s: (
+        s.m._repr_latex_() + r'\ ' + s.u._repr_latex_()
+        if hasattr(s.m, '_repr_latex_') else '${:~L}$'.format(s)
+    )
+    L = 1.23456789 * sympy.symbols('a') * kip
+    assert round_and_render_line_objects_to_latex(
+        CalcLine([L], '', ''), precision=3, dec_sep='.'
+    ).latex == r'\displaystyle 1.235 a\ \mathrm{kip}'

--- a/test_handcalcs/test_sympy_kit.py
+++ b/test_handcalcs/test_sympy_kit.py
@@ -1,5 +1,8 @@
 import inspect
 from collections import deque
+from handcalcs.handcalcs import (
+    CalcLine, round_and_render_line_objects_to_latex
+)
 import handcalcs.sympy_kit as sk
 import pathlib
 import pytest
@@ -49,3 +52,15 @@ def test_convert_sympy_cell_to_py_cell():
     )
     with pytest.raises(ValueError):
         sk.convert_sympy_cell_to_py_cell("c", {"x": 9, "y": 10, "c": c})
+
+
+def test_sympy_rounding():
+    expr = 12.3456789 * a + 1.23456789e-55 * b
+
+    assert round_and_render_line_objects_to_latex(
+        CalcLine([expr], '', ''), precision=3, dec_sep='.'
+    ).latex == r'\displaystyle 12.346 a + 1.235 \cdot 10^{-55} b'
+
+    assert round_and_render_line_objects_to_latex(
+        CalcLine([expr], '', ''), precision=4, dec_sep='.'
+    ).latex == r'\displaystyle 12.3457 a + 1.2346 \cdot 10^{-55} b'


### PR DESCRIPTION
- [x] SymPy expressions, including SymPy Floats in scientific notation
- [x] Pint quantities, including those containing a SymPy expression
- [x] Nested objects, including lists and NumPy arrays