### PR TITLE
Revise render and tex to use IPython needs_local_scope decorator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,11 @@
-pyparsing>=2.4.0
+pyparsing >= 2.4.0
 innerscope >= 0.2.0
 more-itertools >= 8.5.0
 nbconvert >= 6.0
+pint >= 0.24.4
+pytest >= 8.4.1
+pytest-cov >= 6.2.1
+sympy >=1.14.0
+jupyterlab >= 4.4.4
+forallpeople >= 2.7.1
+black >= 25.1.0

--- a/src/handcalcs/__init__.py
+++ b/src/handcalcs/__init__.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 """
-Render arithmetic calucations in Jupyter as though they were written by hand.
+Render arithmetic calculations in Jupyter as though they were written by hand.
 """
 __version__ = "1.11.0"  #
 from .decorator import handcalc

--- a/src/handcalcs/render.py
+++ b/src/handcalcs/render.py
@@ -14,6 +14,7 @@
 
 
 import sys
+
 from . import handcalcs as hand
 from . import sympy_kit as s_kit
 
@@ -24,6 +25,7 @@ try:
         cell_magic,
         register_cell_magic,
         register_line_magic,
+        needs_local_scope,
     )
     from IPython import get_ipython
     from IPython.display import Latex, Markdown, display
@@ -83,43 +85,42 @@ def decimal_separator(line):
 
 
 @register_cell_magic
-def render(line, cell):
-    # Retrieve var dict from user namespace
-    user_ns_prerun = ip.user_ns
-    line_args = parse_line_args(line)
-
-    if line_args["sympy"]:
-        cell = s_kit.convert_sympy_cell_to_py_cell(cell, user_ns_prerun)
-
-    # Run the cell
-    with cell_capture:
-        exec_result = ip.run_cell(cell)
-
-    if not exec_result.success:
-        return None
-
-    # Retrieve updated variables (after .run_cell(cell))
-    user_ns_postrun = ip.user_ns
-
-    # Do the handcalc conversion
-    renderer = hand.LatexRenderer(cell, user_ns_postrun, line_args)
-    latex_code = renderer.render()
-
-    # Display, but not as an "output"
-    display(Latex(latex_code))
-
-    if line_args["override"] == "_testing":
-        return latex_code
+@needs_local_scope
+def render(line, cell, local_ns:dict):
+    # willysw: revised to remove duplicate code. 2026-04-15
+    return _render(line, cell, local_ns, display_latex=True)
 
 
 @register_cell_magic
-def tex(line, cell):
-    # Retrieve var dict from user namespace
-    user_ns_prerun = ip.user_ns
+@needs_local_scope
+def tex(line, cell, local_ns:dict):
+    # willysw: revised to remove duplicate code. 2026-04-15
+    return _render(line, cell, local_ns, display_latex=False)
+
+def _render(line: str, cell: str, local_ns: dict, display_latex: bool = True):
+    """Executes a given cell of code, optionally converts it from SymPy to Python, and renders
+    its output using LaTeX formatting.
+
+    Args:
+        line: The input command line and optional arguments.
+        cell: The code cell to be executed.
+        local_ns: A dictionary containing the user's local namespace.
+        display_latex: A boolean flag indicating whether to display the rendered LaTeX output
+                       using IPython's display system. Defaults to True.
+
+    Returns:
+        Either None or a string containing the LaTeX code. Returns None in most cases, except
+        when the override argument is set to `_testing`.
+    """
+    # willysw: added local_ns to pass in the user namespace.
+    # local_ns is a live reference to the local namespace and
+    # not a copy. No need to track before and after. 2026-04-15
+
+    # Parse the line arguments
     line_args = parse_line_args(line)
 
     if line_args["sympy"]:
-        cell = s_kit.convert_sympy_cell_to_py_cell(cell, user_ns_prerun)
+        cell = s_kit.convert_sympy_cell_to_py_cell(cell, local_ns)
 
     # Run the cell
     with cell_capture:
@@ -128,18 +129,21 @@ def tex(line, cell):
     if not exec_result.success:
         return None
 
-    # Retrieve updated variables (after .run_cell(cell))
-    user_ns_postrun = ip.user_ns
-
     # Do the handcalc conversion
-    renderer = hand.LatexRenderer(cell, user_ns_postrun, line_args)
+    renderer = hand.LatexRenderer(cell, local_ns, line_args)
     latex_code = renderer.render()
 
-    # Display, but not as an "output"
-    print(latex_code)
+    if display_latex:
+        # Display as IPython.display.Latex
+        display(Latex(latex_code))
+    else:
+        # Display, but not as an "output"
+        print(latex_code)
 
     if line_args["override"] == "_testing":
         return latex_code
+    else:
+        return None
 
 
 def load_ipython_extension(ipython):

--- a/src/handcalcs/render.py
+++ b/src/handcalcs/render.py
@@ -30,13 +30,10 @@ try:
     from IPython import get_ipython
     from IPython.display import Latex, Markdown, display
     from IPython.utils.capture import capture_output
-except ImportError:
-    pass
 
-
-try:
     ip = get_ipython()
     cell_capture = capture_output(stdout=True, stderr=True, display=True)
+
 except AttributeError:
     raise ImportError(
         "handcalcs.render is intended for a Jupyter environment."
@@ -50,15 +47,11 @@ def parse_line_args(line: str) -> dict:
     passed in as a line on the %%render or %%tex cell magics.
     """
     valid_args = ["params", "long", "short", "sympy", "symbolic", "_testing"]
-    # valid_args = ["params", "long", "short", "sympy", "symbolic", "_testing"]
     sympy_arg = ["sympy"]
     line_parts = line.split()
     parsed_args = {"override": "", "precision": None, "sympy": False, "sci_not": None}
-    # parsed_args = {
-    #     "override": "",
-    #     "precision": "",
-    # }
     precision = ""
+
     for arg in line_parts:
         if arg.lower() in sympy_arg:
             parsed_args["sympy"] = True
@@ -86,16 +79,15 @@ def decimal_separator(line):
 
 @register_cell_magic
 @needs_local_scope
-def render(line, cell, local_ns:dict):
-    # willysw: revised to remove duplicate code. 2026-04-15
+def render(line, cell, local_ns: dict):
     return _render(line, cell, local_ns, display_latex=True)
 
 
 @register_cell_magic
 @needs_local_scope
-def tex(line, cell, local_ns:dict):
-    # willysw: revised to remove duplicate code. 2026-04-15
+def tex(line, cell, local_ns: dict):
     return _render(line, cell, local_ns, display_latex=False)
+
 
 def _render(line: str, cell: str, local_ns: dict, display_latex: bool = True):
     """Executes a given cell of code, optionally converts it from SymPy to Python, and renders
@@ -112,9 +104,6 @@ def _render(line: str, cell: str, local_ns: dict, display_latex: bool = True):
         Either None or a string containing the LaTeX code. Returns None in most cases, except
         when the override argument is set to `_testing`.
     """
-    # willysw: added local_ns to pass in the user namespace.
-    # local_ns is a live reference to the local namespace and
-    # not a copy. No need to track before and after. 2026-04-15
 
     # Parse the line arguments
     line_args = parse_line_args(line)


### PR DESCRIPTION
**Revised render() and tex():**
1. Use the IPython.core.magic.needs_local_scope() decorator. This method passes a live reference to the namespace instead of a copy and simplifies the code.
2. Added a protected function _render() to eliminate code duplication between tex() and render().
3. Revised the imports into one try block.

*This is my first pull request. Let me know if I should be doing anything differently.*