### PR TITLE
Add cbrt() support for cube root LaTeX rendering

### DIFF
--- a/src/handcalcs/handcalcs.py
+++ b/src/handcalcs/handcalcs.py
@@ -2680,7 +2680,7 @@ def swap_math_funcs(
             func_name_match = get_func_latex(poss_func_name)
             if poss_func_name != func_name_match:
                 item = swap_func_name(item, poss_func_name)
-                if poss_func_name == "sqrt":
+                if poss_func_name in ("sqrt", "cbrt"):
                     item = insert_func_braces(item)
                 new_item = swap_math_funcs(item, calc_results)
                 swapped_deque.append(new_item)
@@ -2721,6 +2721,7 @@ def get_func_latex(func: str, **config_options) -> str:
         "cos": "\\cos",
         "tan": "\\tan",
         "sqrt": "\\sqrt",
+        "cbrt": "\\sqrt[3]",
         "exp": "\\exp",
         "sinh": "\\sinh",
         "tanh": "\\tanh",
@@ -3278,7 +3279,7 @@ def insert_parentheses(pycode_as_deque: deque, **config_options) -> deque:
     peekable_deque = more_itertools.peekable(pycode_as_deque)
     lpar = "\\left("
     prev_item = None
-    func_exclude = ["sqrt", "quad", "integrate"]
+    func_exclude = ["sqrt", "cbrt", "quad", "integrate"]
     skip_fraction_token = False
     for item in peekable_deque:
         next_item = peekable_deque.peek(False)


### PR DESCRIPTION
## Summary

Adds `cbrt()` function support so it renders as `\sqrt[3]{x}` in LaTeX output, matching the same pattern as `sqrt()`.

**Changes (3 lines in `handcalcs.py`):**
- Added `"cbrt": "\\sqrt[3]"` to the `get_func_latex()` lookup table
- Added `cbrt` to the `insert_func_braces` check (uses `{}` instead of `()`, same as `sqrt`)
- Added `cbrt` to `func_exclude` list (skip parentheses insertion, same as `sqrt`)

All 45 existing tests pass.

Closes #225

## Context

Discussion in #225 with @av-engineering suggested adding `cbrt` support as a simpler alternative to a general `nth_root(x, n)` function. This follows the approach they outlined.