### PR TITLE
feat: add trailing_zeros config option to control trailing zero display

### DIFF
--- a/src/handcalcs/config.json
+++ b/src/handcalcs/config.json
@@ -12,5 +12,6 @@
     "param_columns": 3,
     "preferred_string_formatter": "L",
     "custom_symbols": {},
-    "custom_brackets": {}
+    "custom_brackets": {},
+    "trailing_zeros": -1
 }

--- a/src/handcalcs/handcalcs.py
+++ b/src/handcalcs/handcalcs.py
@@ -1057,8 +1057,9 @@ def round_and_render_calc(
         config_options["use_scientific_notation"], cell_notation
     )
     preferred_formatter = config_options["preferred_string_formatter"]
+    trailing_zeros = config_options.get("trailing_zeros")
     rendered_line = render_latex_str(
-        idx_line, use_scientific_notation, precision, preferred_formatter
+        idx_line, use_scientific_notation, precision, preferred_formatter, trailing_zeros
     )
     rendered_line = swap_dec_sep(rendered_line, config_options["decimal_separator"])
     line.line = rendered_line
@@ -1076,8 +1077,9 @@ def round_and_render_numericcalc(
         config_options["use_scientific_notation"], cell_notation
     )
     preferred_formatter = config_options["preferred_string_formatter"]
+    trailing_zeros = config_options.get("trailing_zeros")
     rendered_line = render_latex_str(
-        idx_line, use_scientific_notation, precision, preferred_formatter
+        idx_line, use_scientific_notation, precision, preferred_formatter, trailing_zeros
     )
     rendered_line = swap_dec_sep(rendered_line, config_options["decimal_separator"])
     line.line = rendered_line
@@ -1095,8 +1097,9 @@ def round_and_render_longcalc(
         config_options["use_scientific_notation"], cell_notation
     )
     preferred_formatter = config_options["preferred_string_formatter"]
+    trailing_zeros = config_options.get("trailing_zeros")
     rendered_line = render_latex_str(
-        idx_line, use_scientific_notation, precision, preferred_formatter
+        idx_line, use_scientific_notation, precision, preferred_formatter, trailing_zeros
     )
     rendered_line = swap_dec_sep(rendered_line, config_options["decimal_separator"])
     line.line = rendered_line
@@ -1114,8 +1117,9 @@ def round_and_render_parameter(
         config_options["use_scientific_notation"], cell_notation
     )
     preferred_formatter = config_options["preferred_string_formatter"]
+    trailing_zeros = config_options.get("trailing_zeros")
     rendered_line = render_latex_str(
-        idx_line, use_scientific_notation, precision, preferred_formatter
+        idx_line, use_scientific_notation, precision, preferred_formatter, trailing_zeros
     )
     rendered_line = swap_dec_sep(rendered_line, config_options["decimal_separator"])
     line.line = rendered_line
@@ -1135,8 +1139,9 @@ def round_and_render_conditional(
         config_options["use_scientific_notation"], cell_notation
     )
     preferred_formatter = config_options["preferred_string_formatter"]
+    trailing_zeros = config_options.get("trailing_zeros")
     rendered_line = render_latex_str(
-        idx_line, use_scientific_notation, precision, preferred_formatter
+        idx_line, use_scientific_notation, precision, preferred_formatter, trailing_zeros
     )
     rendered_line = swap_dec_sep(rendered_line, config_options["decimal_separator"])
     line.line = rendered_line
@@ -1168,8 +1173,9 @@ def round_and_render_symbolic(
         config_options["use_scientific_notation"], cell_notation
     )
     preferred_formatter = config_options["preferred_string_formatter"]
+    trailing_zeros = config_options.get("trailing_zeros")
     rendered_line = render_latex_str(
-        idx_line, use_scientific_notation, precision, preferred_formatter
+        idx_line, use_scientific_notation, precision, preferred_formatter, trailing_zeros
     )
     rendered_line = swap_dec_sep(rendered_line, config_options["decimal_separator"])
     line.line = rendered_line
@@ -1191,11 +1197,24 @@ def round_and_render_intertext(
     return line
 
 
+def strip_trailing_zeros(s: str, min_trailing_zeros) -> str:
+    """Strip trailing zeros, keeping at most min_trailing_zeros (never adds beyond what exists)."""
+    if min_trailing_zeros is None or min_trailing_zeros < 0 or "." not in s:
+        return s
+    integer_part, decimal_part = s.split(".", 1)
+    stripped = decimal_part.rstrip("0")
+    zeros_removed = len(decimal_part) - len(stripped)
+    zeros_to_keep = min(min_trailing_zeros, zeros_removed)
+    decimal_part = stripped + "0" * zeros_to_keep
+    return f"{integer_part}.{decimal_part}" if decimal_part else integer_part
+
+
 def render_latex_str(
     line_of_code: deque,
     use_scientific_notation: bool,
     precision: int,
     preferred_formatter: str,
+    trailing_zeros: int = -1,
 ) -> deque:
     """
     Returns a rounded str based on the latex_repr of an object in
@@ -1204,14 +1223,18 @@ def render_latex_str(
     outgoing = deque([])
     for item in line_of_code:
         rendered_str = latex_repr(
-            item, use_scientific_notation, precision, preferred_formatter
+            item, use_scientific_notation, precision, preferred_formatter, trailing_zeros
         )
         outgoing.append(rendered_str)
     return outgoing
 
 
 def latex_repr(
-    item: Any, use_scientific_notation: bool, precision: int, preferred_formatter: str
+    item: Any,
+    use_scientific_notation: bool,
+    precision: int,
+    preferred_formatter: str,
+    trailing_zeros: int = -1,
 ) -> str:
     """
     Return a str if the object, 'item', has a special repr method
@@ -1226,7 +1249,7 @@ def latex_repr(
                 + comma_space.join(
                     [
                         latex_repr(
-                            v, use_scientific_notation, precision, preferred_formatter
+                            v, use_scientific_notation, precision, preferred_formatter, trailing_zeros
                         )
                         for v in item
                     ]
@@ -1258,6 +1281,7 @@ def latex_repr(
             rendered_string = f"{item:.{precision}e{preferred_formatter}}"
         else:
             rendered_string = f"{item:.{precision}f{preferred_formatter}}"
+            rendered_string = strip_trailing_zeros(rendered_string, trailing_zeros)
     except (ValueError, TypeError):
         try:
             if use_scientific_notation and isinstance(item, complex):
@@ -1275,6 +1299,7 @@ def latex_repr(
                 rendered_string = swap_scientific_notation_str(rendered_string)
             elif not isinstance(item, int):
                 rendered_string = f"{item:.{precision}f}"
+                rendered_string = strip_trailing_zeros(rendered_string, trailing_zeros)
             else:
                 rendered_string = str(item)
         except (ValueError, TypeError):

--- a/test_handcalcs/test_handcalcs_file.py
+++ b/test_handcalcs/test_handcalcs_file.py
@@ -1889,3 +1889,61 @@ def test_for_numeric_line():
         )
         == True
     )
+
+
+# Trailing zeros tests
+
+
+def test_strip_trailing_zeros():
+    strip = handcalcs.handcalcs.strip_trailing_zeros
+    # Disabled sentinels — return unchanged
+    assert strip("11.000", -1) == "11.000"
+    assert strip("11.000", None) == "11.000"
+    # Remove all trailing zeros
+    assert strip("11.000", 0) == "11"
+    assert strip("1.500", 0) == "1.5"
+    # Keep N trailing zeros
+    assert strip("11.000", 1) == "11.0"
+    assert strip("11.000", 2) == "11.00"
+    assert strip("11.000", 3) == "11.000"
+    # Zeros kept cannot exceed zeros that exist
+    assert strip("1.100", 1) == "1.10"
+    assert strip("1.550", 2) == "1.550"   # only 1 trailing zero; keeps 1 not 2
+    # No trailing zeros — no effect regardless of min_trailing_zeros
+    assert strip("1.567", 0) == "1.567"
+    assert strip("1.567", 1) == "1.567"
+    # No decimal point — no effect
+    assert strip("11", 0) == "11"
+    assert strip("11", 2) == "11"
+
+
+def test_latex_repr_trailing_zeros():
+    latex_repr = handcalcs.handcalcs.latex_repr
+    # Default (-1) — precision controls fully, no stripping
+    assert latex_repr(11.0, False, 3, "") == "11.000"
+    assert latex_repr(11.0, False, 3, "", -1) == "11.000"
+    # Remove all trailing zeros
+    assert latex_repr(11.0, False, 3, "", 0) == "11"
+    assert latex_repr(1.5, False, 3, "", 0) == "1.5"
+    # Keep N trailing zeros
+    assert latex_repr(11.0, False, 3, "", 1) == "11.0"
+    assert latex_repr(11.0, False, 3, "", 2) == "11.00"
+    assert latex_repr(1.1, False, 3, "", 1) == "1.10"
+    # No trailing zeros in value — trailing_zeros has no effect
+    assert latex_repr(1.567, False, 3, "", 1) == "1.567"
+    # Integers have no decimal — no effect
+    assert latex_repr(11, False, 3, "", 0) == "11"
+    # Scientific notation path — trailing_zeros is not applied
+    assert latex_repr(11.0, True, 3, "", 0) == latex_repr(11.0, True, 3, "")
+
+
+def test_render_latex_str_trailing_zeros():
+    render = handcalcs.handcalcs.render_latex_str
+    # Remove all trailing zeros across a full line
+    assert render(deque([11.0, "+", 2.0]), False, 3, "", 0) == deque(["11", "+", "2"])
+    # Keep one trailing zero
+    assert render(deque([11.0, "+", 1.1]), False, 3, "", 1) == deque(["11.0", "+", "1.10"])
+    # -1 (default) — no stripping
+    assert render(deque([11.0]), False, 3, "", -1) == deque(["11.000"])
+    # Non-numeric tokens are left untouched
+    assert render(deque(["=", 11.0]), False, 3, "", 0) == deque(["=", "11"])


### PR DESCRIPTION
## Summary

Adds a new `trailing_zeros` config option that gives users control over how many trailing zeros are kept after rounding, without affecting precision.

- `trailing_zeros = -1` (default) — disabled, precision controls output fully (`11.000` stays `11.000`)
- `trailing_zeros = 0` — strip all trailing zeros (`11.000` → `11`)
- `trailing_zeros = N` — keep at most N trailing zeros (`11.000` with N=1 → `11.0`, `1.100` with N=1 → `1.10`)

The feature never adds zeros beyond what the formatted string already has — it only removes them.

## Implementation

- `strip_trailing_zeros(s, min_trailing_zeros)` — new helper that handles `None` and negative sentinels gracefully by returning the string unchanged
- `latex_repr` and `render_latex_str` — `trailing_zeros` parameter threaded through; applied on plain float paths only (scientific notation, integers, and complex numbers are unaffected)
- All 6 `round_and_render_*` dispatch functions extract `trailing_zeros` from `config_options` and pass it through
- Uses `-1` as the disabled sentinel for compatibility with `set_option` type checking (consistent with `array_truncate_threshold` in the array branch)

## Usage

```python
import handcalcs
handcalcs.set_option("trailing_zeros", 0)   # strip all
handcalcs.set_option("trailing_zeros", 1)   # keep one
handcalcs.set_option("trailing_zeros", -1)  # reset to default
```

## Tests

63 tests passing. New tests added covering:
- `strip_trailing_zeros` — disabled sentinels, strip all, keep N, cannot exceed existing zeros, no trailing zeros, no decimal point
- `latex_repr` — all paths including scientific notation (unaffected), integers (unaffected)
- `render_latex_str` — full pipeline integration