### PR TITLE
Unit tests for nodes + BaseRenderer, six bug fixes, and ExprLine rendering

### DIFF
--- a/src/handcalcs/parsing/ast_parser.py
+++ b/src/handcalcs/parsing/ast_parser.py
@@ -601,14 +601,8 @@ class AST_Parser:
 
         elif isinstance(node, ast.Expr):
             # An expression used as a statement (e.g., a standalone function call)
-            if isinstance(node.value, ast.Constant):
-                doc_string = f"Doc string: {self.ast_parse(node.value)}"
-                val = ExprLine(expression_tree=deque([doc_string]))
-            else:
-                parsed_node = self.ast_parse(node.value)
-                if not isinstance(parsed_node, deque):
-                    parsed_node = deque([parsed_node])
-                val = ExprLine(expression_tree=parsed_node)
+            parsed_node = self.ast_parse(node.value)
+            val = ExprLine(expression_tree=deque([parsed_node]))
 
         # Default case for unhandled nodes: val = a simple string for clarity
         else:

--- a/src/handcalcs/renderers/base.py
+++ b/src/handcalcs/renderers/base.py
@@ -476,37 +476,50 @@ def render_calcline(renderer: BaseRenderer, node: CalcLine, base_context: BaseRe
 
 @BaseRenderer.register('expr_line')
 def render_exprline(renderer: BaseRenderer, node: ExprLine, base_context: BaseRenderContext) -> str:
+    """
+    Render a bare expression statement (an ExprLine).
+
+    An ExprLine has no assignment target, so there is no result column. Until a
+    value-capture pass exists, the three kinds of ExprLine are classified and
+    rendered honestly (no dangling equals, no fabricated result):
+
+    - *docstring / bare string*: the expression tree is a single ``str`` (built
+      by the parser for a string-literal statement); render it as a plain line.
+    - *return statement* (``return_expr``): lives inside a symbolic function
+      definition whose names have no runtime value, so render the symbolic form
+      only -- no numeric substitution.
+    - *ordinary expression statement* (e.g. ``print(x)``, ``x + y``): render the
+      symbolic form and its numeric substitution joined by the equality, with no
+      trailing equals and no result.
+    """
     context = base_context.current
-    rendered = f"{context.indent * node.level}"
+    indent = f"{context.indent * node.level}"
+
+    # A bare string-literal statement (e.g. a module or block docstring) is a
+    # single Constant holding a str; render it as a plain line, not a calc.
+    tree = node.expression_tree
+    if len(tree) == 1 and isinstance(tree[0], Constant) and isinstance(tree[0].value, str):
+        return f"{indent}{tree[0].value}{context.newline}"
+
+    def render_tree(mode: str) -> str:
+        base_context.line_context.current_mode = mode
+        return "".join(renderer.render(subnode, base_context) for subnode in node.expression_tree)
+
+    portions = deque([])
     if context.mode == 'full' or 'sym' in context.mode:
-        base_context.line_context.current_mode = 'sym'
-        symbolic = deque([])
-        for subnode in node.expression_tree:
-            symbolic.append(renderer.render(subnode, base_context))
-        symbolic = "".join(symbolic)
-        symbolic_portion = f"{symbolic}{context.space}{context.equality}{context.space}"
-        rendered += symbolic_portion
-    if context.mode == "full" or "num" in context.mode:
-        base_context.line_context.current_mode = "num"
-        numeric = deque([])
-        for subnode in node.expression_tree:
-            numeric.append(renderer.render(subnode, base_context))
-        numeric = "".join(numeric)
-        numeric_portion = f"{numeric}{context.space}{context.equality}{context.space}"
-        rendered += numeric_portion
-    # if context.mode == "full" or "res" in context.mode:
-    #     context.current_mode = "num"
-    #     result = node.assign.value
-    #     for rule in renderer.numeric_rules:
-    #         result = rule(result, base_context)
-    #     result_portion = f"{result}"
-    #     rendered += result_portion
+        portions.append(render_tree('sym'))
+    # A return statement has no single runtime value; omit numeric substitution.
+    if not node.return_expr and (context.mode == 'full' or 'num' in context.mode):
+        portions.append(render_tree('num'))
+
+    joiner = f"{context.space}{context.equality}{context.space}"
+    rendered = f"{indent}{joiner.join(portions)}"
+
     if node.comment is not None:
-        comment_portion = renderer.render(node.comment, base_context)
-        rendered += comment_portion
-    ready_for_next_line = f"{rendered}{context.newline}"
-    return rendered
-    
+        rendered += renderer.render(node.comment, base_context)
+
+    return f"{rendered}{context.newline}"
+
 
 @BaseRenderer.register('elif_block')
 def render_elifblock(renderer: BaseRenderer, node: ElifBlock, base_context: BaseRenderContext) -> str:
@@ -554,7 +567,9 @@ def render_if_block(renderer: BaseRenderer, node: IfBlock, base_context: BaseRen
     lines_acc = []
     for line in node.lines:
         lines_acc.append(renderer.render(line, base_context))
-    lines = f"{context.newline}".join(lines_acc)
+    # Rendered lines already self-terminate with a newline, so concatenate
+    # them directly rather than re-inserting newlines between them.
+    lines = "".join(lines_acc)
 
     # Indent the block header appropriately
     block_header = f"{context.indent * node.level}{if_block_header}"

--- a/src/handcalcs/renderers/base.py
+++ b/src/handcalcs/renderers/base.py
@@ -90,7 +90,7 @@ class RenderContext:
         if not isinstance(other, self.__class__):
             raise ValueError(f"Can only union between two RenderContexts, not {type(other)}.")
         else:
-            return RenderContext(self.__dict__ | other.__dict__)
+            return RenderContext(**(self.__dict__ | other.__dict__))
 
 
 class BaseRenderContext:
@@ -150,11 +150,11 @@ class BaseRenderer:
         """
         Render an HcSequence (root node) with the registered pre/post render callables.
         """
-        parts = [pre(self, root, base_context) for pre in self._root_pre_renderers]
+        parts = [pre(self, root, base_context) for pre in self._root_pre_renderers.values()]
         for node in root.sequence:
             parts.append(self.render(node, base_context))
         parts.extend(
-            [post(self, root, base_context) for post in self._root_post_renderers]
+            [post(self, root, base_context) for post in self._root_post_renderers.values()]
         )
         return parts
 
@@ -162,9 +162,9 @@ class BaseRenderer:
         """
         Render one node with an existing context.
         """
-        for rule in self.symbolic_rules.values():
+        for rule in self._symbolic_rules.values():
             node = rule(node, base_context)
-        for rule in self.numeric_rules.values():
+        for rule in self._numeric_rules.values():
             node = rule(node, base_context)
         context = base_context.current
         handler = self._handlers.get(node.type)
@@ -348,8 +348,7 @@ def render_neq_op(renderer: BR, node: NeqOp, base_context: BaseRenderContext) ->
 
 @BaseRenderer.register('compare')
 def render_compare(renderer: BR, node: Compare, base_context: BaseRenderContext) -> str:
-    context = base_context.current
-    acc = [renderer.render(node, context) for node in node.comparison]
+    acc = [renderer.render(elem, base_context) for elem in node.comparison]
     return f"".join(acc)
 
 @BaseRenderer.register('function_call')
@@ -381,7 +380,7 @@ def render_comment_command(renderer: BR, node: CommentLine, base_context: BaseRe
 
 @BaseRenderer.register('markdown_comment')
 def render_markdown_comment(renderer: BR, node: MarkdownComment, base_context: BaseRenderContext) -> str:
-    return node.comment
+    return node.content
 
 
 @BaseRenderer.register('inline_command')
@@ -480,7 +479,7 @@ def render_exprline(renderer: BaseRenderer, node: ExprLine, base_context: BaseRe
     context = base_context.current
     rendered = f"{context.indent * node.level}"
     if context.mode == 'full' or 'sym' in context.mode:
-        context.current_mode = 'sym'
+        base_context.line_context.current_mode = 'sym'
         symbolic = deque([])
         for subnode in node.expression_tree:
             symbolic.append(renderer.render(subnode, base_context))
@@ -488,7 +487,7 @@ def render_exprline(renderer: BaseRenderer, node: ExprLine, base_context: BaseRe
         symbolic_portion = f"{symbolic}{context.space}{context.equality}{context.space}"
         rendered += symbolic_portion
     if context.mode == "full" or "num" in context.mode:
-        context.current_mode = "num"
+        base_context.line_context.current_mode = "num"
         numeric = deque([])
         for subnode in node.expression_tree:
             numeric.append(renderer.render(subnode, base_context))
@@ -570,7 +569,7 @@ def toggle_param_line(node: CalcLine | HcNode, base_context:BRC) -> HcNode:
     context = base_context.current
     if node.type not in ('calc_line',):
         base_context.line_context.param_line = False
-    elif context.param_line == True:
+    elif getattr(context, 'param_line', False) == True:
         return node
     else:
         if (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,73 @@
+"""
+Shared scaffolding for the handcalcs v2 unit tests.
+
+The tests in this suite exercise nodes and the ``BaseRenderer`` in isolation:
+nodes are constructed directly (not produced by the parser) and rendered
+through a bare ``BaseRenderer`` with a controlled context. This keeps
+node/render behavior decoupled from parser correctness (covered by
+``test_parser.py``) and keeps the concrete renderers out of scope.
+"""
+import pytest
+
+from handcalcs.renderers.base import BaseRenderer, RenderContext, BaseRenderContext
+
+
+# Sensible global-context defaults for rendering a single node in isolation.
+# ``format_code`` is the constructor kwarg that populates ``RenderContext.format``.
+_DEFAULT_GLOBALS = dict(
+    space=" ",
+    newline="\n",
+    indent="    ",
+    equality="=",
+    mode="full",
+    format_code=".5g",
+)
+
+
+@pytest.fixture
+def renderer():
+    """A fresh, un-subclassed ``BaseRenderer`` instance."""
+    return BaseRenderer()
+
+
+@pytest.fixture
+def make_context():
+    """
+    Factory building a ``BaseRenderContext`` for isolated node rendering.
+
+    ``line`` is a dict of line-context keys (e.g. ``{"current_mode": "sym"}``);
+    any other keyword overrides a global-context default.
+    """
+    def _factory(*, line=None, **global_overrides):
+        globals_ = {**_DEFAULT_GLOBALS, **global_overrides}
+        line_ctx = RenderContext(**line) if line else RenderContext()
+        return BaseRenderContext(RenderContext(**globals_), line_ctx)
+
+    return _factory
+
+
+@pytest.fixture
+def render(renderer, make_context):
+    """
+    One-liner render helper.
+
+    All overrides are placed on the *line* context, not the global one. This
+    is deliberate: ``BaseRenderContext.current`` overlays the line context over
+    the global context via ``ChainMap``, and a ``RenderContext()`` is always
+    fully populated with defaults -- so a line-context value always wins over
+    the corresponding global-context value. Putting per-test overrides
+    (including ``current_mode``, required by ``Name``) on the line layer is the
+    only way for them to take effect::
+
+        render(Constant(4))
+        render(Name("alpha", 3), current_mode="num")
+        render(node, mode="sym", format_code=".2f")
+    """
+    def _render(node, *, current_mode=None, **overrides):
+        line = dict(overrides)
+        if current_mode is not None:
+            line["current_mode"] = current_mode
+        ctx = make_context(line=line or None)
+        return renderer.render(node, ctx)
+
+    return _render

--- a/tests/test_base_renderer.py
+++ b/tests/test_base_renderer.py
@@ -1,0 +1,186 @@
+"""
+Tests for the ``BaseRenderer`` machinery itself, independent of any single
+node handler: dispatch, the class-vs-instance handler registry, classifier
+parsing, context layering, and the sym/num rule pipelines.
+
+Bugs discovered while writing these tests are documented with
+``pytest.mark.xfail(strict=True)`` so the suite records current behavior and
+notifies (via an unexpected pass) when a bug is fixed.
+"""
+from collections import deque
+
+import pytest
+
+from handcalcs.renderers.base import (
+    BaseRenderer,
+    RenderContext,
+    BaseRenderContext,
+)
+from handcalcs.parsing.nodes import Constant
+from handcalcs.parsing.sequence import HcSequence
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+def test_render_routes_root_to_render_root(renderer):
+    root = HcSequence(deque([Constant(1), Constant(2)]))
+    parts = renderer.render(root)
+    # render_root returns a list of parts, one per sequence node (+ pre/post).
+    assert isinstance(parts, list)
+    assert parts == ["1", "2"]
+
+
+def test_render_node_dispatches_by_type(render):
+    assert render(Constant(4)) == "4"
+
+
+def test_unknown_node_type_falls_back_to_str(render):
+    class Mystery:
+        type = "no_such_handler"
+
+        def __repr__(self):
+            return "MYSTERY"
+
+    assert render(Mystery()) == "MYSTERY"
+
+
+def test_render_creates_default_context_when_none_given(renderer):
+    # Constant does not require line context, so a bare render must work.
+    assert renderer.render(Constant(7)) == "7"
+
+
+# ---------------------------------------------------------------------------
+# Registry: instance vs class isolation
+# ---------------------------------------------------------------------------
+
+def test_register_handler_is_instance_scoped(renderer):
+    renderer.register_handler("faketype", lambda rn, node, ctx: "X")
+    assert "faketype" in renderer._handlers
+    assert "faketype" not in BaseRenderer.node_handlers
+
+
+def test_register_classmethod_scopes_to_subclass():
+    class SubR(BaseRenderer):
+        pass
+
+    @SubR.register("mytype")
+    def _handler(rn, node, ctx):  # noqa: ARG001
+        return "ok"
+
+    assert "mytype" in SubR.node_handlers
+    assert "mytype" not in BaseRenderer.node_handlers
+
+
+def test_subclass_gets_independent_handler_copies():
+    class SubR(BaseRenderer):
+        pass
+
+    SubR.node_handlers["only_on_sub"] = lambda *a: "s"
+    assert "only_on_sub" not in BaseRenderer.node_handlers
+
+
+# ---------------------------------------------------------------------------
+# Classifier parsing in register_handler
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "prefix,target_attr",
+    [
+        ("pre", "_root_pre_renderers"),
+        ("post", "_root_post_renderers"),
+        ("sym", "_symbolic_rules"),
+        ("num", "_numeric_rules"),
+    ],
+)
+def test_register_handler_routes_prefixes(renderer, prefix, target_attr):
+    renderer.register_handler(f"{prefix}:thing", lambda *a: None)
+    assert "thing" in getattr(renderer, target_attr)
+
+
+def test_register_handler_bare_name_is_node_handler(renderer):
+    renderer.register_handler("some_node", lambda *a: None)
+    assert "some_node" in renderer._handlers
+
+
+def test_register_handler_unknown_prefix_raises(renderer):
+    with pytest.raises(NotImplementedError):
+        renderer.register_handler("bogus:thing", lambda *a: None)
+
+
+def test_register_handler_two_colons_treated_as_node_name(renderer):
+    # Only a single colon triggers prefix routing; otherwise it is a node name.
+    renderer.register_handler("a:b:c", lambda *a: None)
+    assert "a:b:c" in renderer._handlers
+
+
+# ---------------------------------------------------------------------------
+# Context layering
+# ---------------------------------------------------------------------------
+
+def test_current_overlays_line_over_global():
+    base = BaseRenderContext(
+        RenderContext(mode="full", format_code=".5g"),
+        RenderContext(mode="sym"),
+    )
+    # Line context wins for shared keys...
+    assert base.current.mode == "sym"
+    # ...and global-only keys remain visible.
+    assert base.current.format == ".5g"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="RenderContext.__or__ passes the merged dict as the first positional "
+    "arg (space), corrupting the context instead of unioning fields.",
+)
+def test_render_context_union_merges_fields():
+    a = RenderContext(mode="full")
+    b = RenderContext(mode="sym", format_code=".2f")
+    merged = a | b
+    assert merged.mode == "sym"
+    assert merged.format == ".2f"
+    # space must remain the string default, not become a dict.
+    assert merged.space == " "
+
+
+# ---------------------------------------------------------------------------
+# Rule pipelines
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="render_root iterates the pre/post renderer dicts (keys) rather than "
+    ".values(), so a registered renderer is a str and is called, raising "
+    "TypeError.",
+)
+def test_root_pre_and_post_renderers_wrap_sequence(renderer):
+    renderer.register_handler("pre:banner", lambda rn, root, ctx: "PRE")
+    renderer.register_handler("post:footer", lambda rn, root, ctx: "POST")
+    root = HcSequence(deque([Constant(1)]))
+    parts = renderer.render(root)
+    assert parts[0] == "PRE"
+    assert parts[-1] == "POST"
+    assert "1" in parts
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="render_node iterates the class-level symbolic_rules/numeric_rules, "
+    "so rules added via the instance register_handler are never applied.",
+)
+def test_instance_registered_sym_rule_is_applied(renderer):
+    seen = []
+
+    def spy(node, base_context):
+        seen.append(node.type)
+        return node
+
+    renderer.register_handler("sym:spy", spy)
+    base = BaseRenderContext(
+        RenderContext(mode="full", format_code=".5g"),
+        RenderContext(current_mode="sym"),
+    )
+    renderer.render(Constant(1), base)
+    assert seen == ["constant"]

--- a/tests/test_base_renderer.py
+++ b/tests/test_base_renderer.py
@@ -130,11 +130,6 @@ def test_current_overlays_line_over_global():
     assert base.current.format == ".5g"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="RenderContext.__or__ passes the merged dict as the first positional "
-    "arg (space), corrupting the context instead of unioning fields.",
-)
 def test_render_context_union_merges_fields():
     a = RenderContext(mode="full")
     b = RenderContext(mode="sym", format_code=".2f")
@@ -149,12 +144,6 @@ def test_render_context_union_merges_fields():
 # Rule pipelines
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="render_root iterates the pre/post renderer dicts (keys) rather than "
-    ".values(), so a registered renderer is a str and is called, raising "
-    "TypeError.",
-)
 def test_root_pre_and_post_renderers_wrap_sequence(renderer):
     renderer.register_handler("pre:banner", lambda rn, root, ctx: "PRE")
     renderer.register_handler("post:footer", lambda rn, root, ctx: "POST")
@@ -165,11 +154,6 @@ def test_root_pre_and_post_renderers_wrap_sequence(renderer):
     assert "1" in parts
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="render_node iterates the class-level symbolic_rules/numeric_rules, "
-    "so rules added via the instance register_handler are never applied.",
-)
 def test_instance_registered_sym_rule_is_applied(renderer):
     seen = []
 

--- a/tests/test_block_nodes.py
+++ b/tests/test_block_nodes.py
@@ -1,0 +1,73 @@
+"""
+Layer-1 data-model tests for block nodes, focused on the branching
+``ElifBlock.from_if_tree`` flattening logic.
+"""
+from collections import deque
+
+import pytest
+
+from handcalcs.parsing.nodes import Name, Constant
+from handcalcs.parsing.line_nodes import CalcLine
+from handcalcs.parsing.block_nodes import (
+    FunctionBlock,
+    ForBlock,
+    IfBlock,
+    ElseBlock,
+    ElifBlock,
+)
+
+
+def _calc(identifier, value):
+    return CalcLine(
+        assigns=deque([Name(identifier)]), expression_tree=deque([Constant(value)])
+    )
+
+
+def test_block_defaults():
+    assert FunctionBlock().type == "function_block"
+    assert FunctionBlock().level == 0
+    assert ForBlock().type == "for_block"
+    assert IfBlock().type == "if_block"
+    assert IfBlock().is_true is None
+    assert ElseBlock().type == "else_block"
+    assert ElifBlock().type == "elif_block"
+
+
+# --- ElifBlock.from_if_tree ---------------------------------------------
+
+def test_from_if_tree_single_if_no_orelse():
+    ib = IfBlock(
+        lines=deque([_calc("d", 4)]),
+        test=deque([Name("a"), ">", Constant(2)]),
+        orelse=deque([]),
+    )
+    eb = ElifBlock.from_if_tree(ib)
+    assert isinstance(eb, ElifBlock)
+    assert [type(x).__name__ for x in eb.lines] == ["IfBlock"]
+
+
+def test_from_if_tree_if_else_appends_else_block():
+    ib = IfBlock(
+        lines=deque([_calc("d", 4)]),
+        test=deque([Name("a"), ">", Constant(2)]),
+        orelse=deque([_calc("d", 6)]),
+    )
+    eb = ElifBlock.from_if_tree(ib)
+    assert [type(x).__name__ for x in eb.lines] == ["IfBlock", "ElseBlock"]
+
+
+def test_from_if_tree_nested_elif_flattens():
+    # if / elif / else, expressed as a nested-orelse IfBlock tree.
+    inner = IfBlock(
+        lines=deque([_calc("d", 5)]),
+        test=deque([Name("a"), ">", Name("b")]),
+        orelse=deque([_calc("d", 6)]),
+    )
+    outer = IfBlock(
+        lines=deque([_calc("d", 4)]),
+        test=deque([Constant(2), "<=", Name("a"), "<", Constant(5)]),
+        orelse=deque([inner]),
+    )
+    eb = ElifBlock.from_if_tree(outer)
+    # Two IfBlock clauses (if + elif) plus a trailing ElseBlock.
+    assert [type(x).__name__ for x in eb.lines] == ["IfBlock", "IfBlock", "ElseBlock"]

--- a/tests/test_handcalcs.py
+++ b/tests/test_handcalcs.py
@@ -1,5 +1,12 @@
+"""
+End-to-end smoke tests for the full HandCalcs pipeline
+(source -> parser -> HcSequence -> default PlainTextRenderer).
+
+These guard the wiring between the layers and pin current rendered output.
+Node- and BaseRenderer-level behavior is covered in the dedicated unit
+modules; here we only assert that a realistic script renders coherently.
+"""
 from handcalcs import HandCalcs
-from rich import print
 
 
 def test_basic_arithmetic():
@@ -20,9 +27,24 @@ if e <= 3:
     else:
         f = 30
     """
-    hc = HandCalcs()
-    print(hc(source))
-    assert False
+    out = HandCalcs()(source)
+
+    assert out == (
+        "[Python import]: from math import sqrt, pi\n\n"
+        "α = 4\n"
+        "β = 5 (Inline comment)\n"
+        "Comment\n"
+        "d = 3\n"
+        "c = ((d)(α + β)) / (π) = ((3)(4 + 5)) / (3.142) = 8.594\n"
+        "Since (e<=3) -> (3.0<=3) is True:\n"
+        "    Since (2<α<β) -> (2<4<5) is True:\n"
+        "        f = 20\n"
+    )
+    # The `# hc: -i` (ignore) line must be suppressed from the output.
+    assert "e =" not in out
+    # Only the satisfied elif branch renders; the others do not.
+    assert "f = 12" not in out
+    assert "f = 30" not in out
 
 
 def test_scripting():
@@ -34,6 +56,10 @@ def circle_area(diam: float) -> float:
 radius = 5
 area = circle_area(2 * radius)
     """
-    hc = HandCalcs()
-    print(hc(source))
-    assert False
+    out = HandCalcs()(source)
+
+    assert out == (
+        "[Python import]: from math import sqrt, pi\n\n"
+        "radius = 5\n"
+        "area =  circle_area((2)(radius))  =  circle_area((2)(5))  = 78.54\n"
+    )

--- a/tests/test_inline_nodes.py
+++ b/tests/test_inline_nodes.py
@@ -1,0 +1,76 @@
+"""
+Layer-1 data-model tests for inline nodes, including the branching
+``InlineCommand.from_raw_comment`` constructor.
+"""
+from collections import deque
+
+import pytest
+
+from handcalcs.parsing.nodes import Name, Constant
+from handcalcs.parsing.operator_nodes import GtOp
+from handcalcs.parsing.inline_nodes import (
+    FunctionCall,
+    Compare,
+    InlineComment,
+    InlineCommand,
+    Comprehension,
+    ComprehensionChain,
+)
+
+
+def test_function_call_defaults():
+    fc = FunctionCall()
+    assert fc.namespace == deque()
+    assert fc.function_name == deque()
+    assert fc.args == deque()
+    assert fc.type == "function_call"
+
+
+def test_compare_holds_comparison_deque():
+    c = Compare(deque([Name("a"), GtOp, Constant(2)]))
+    assert c.type == "compare"
+    assert len(c.comparison) == 3
+
+
+def test_inline_comment_node():
+    ic = InlineComment("a note")
+    assert ic.content == "a note"
+    assert ic.type == "inline_comment"
+
+
+def test_comprehension_and_chain_defaults():
+    comp = Comprehension(
+        assigns=deque([Name("elem")]),
+        iterator=deque([Name("a")]),
+        _is_async=False,
+    )
+    assert comp.type == "comprehension"
+    assert comp._is_async is False
+
+    chain = ComprehensionChain(_type="list")
+    assert chain.type == "comprehension_chain"
+    assert chain._type == "list"
+    assert chain.comprehensions == deque()
+
+
+# --- InlineCommand.from_raw_comment: three code paths --------------------
+
+def test_from_raw_comment_non_command_returns_inline_comment():
+    result = InlineCommand.from_raw_comment("an inline note")
+    assert isinstance(result, InlineComment)
+    assert result.content == "an inline note"
+
+
+def test_from_raw_comment_kwarg_style():
+    result = InlineCommand.from_raw_comment("hc: precision=3")
+    assert isinstance(result, InlineCommand)
+    assert result.commands == {"precision": 3}
+
+
+def test_from_raw_comment_flag_style_falls_back_to_argparse():
+    result = InlineCommand.from_raw_comment("hc: -f 5E")
+    assert isinstance(result, InlineCommand)
+    assert result.commands["format"] == "5E"
+    # argparse defaults are present alongside the parsed flag.
+    assert result.commands["multiline"] is False
+    assert result.commands["ignore"] is False

--- a/tests/test_line_nodes.py
+++ b/tests/test_line_nodes.py
@@ -1,0 +1,100 @@
+"""
+Layer-1 data-model tests for line nodes, including the ``from_raw_comment``
+constructors on the comment line types.
+"""
+from collections import deque
+
+import pytest
+
+from handcalcs.parsing.nodes import Name, Constant
+from handcalcs.parsing.line_nodes import (
+    CalcLine,
+    ExprLine,
+    CommentLine,
+    MarkdownComment,
+    CommentCommand,
+    Import,
+)
+from handcalcs.parsing.inline_nodes import InlineComment
+
+
+def test_calc_line_defaults():
+    cl = CalcLine(assigns=deque([Name("a")]), expression_tree=deque([Constant(1)]))
+    assert cl.level == 0
+    assert cl.comment is None
+    assert cl.pars_nesting is False
+    assert cl.type == "calc_line"
+
+
+def test_calc_line_with_comment():
+    cl = CalcLine(
+        assigns=deque([Name("a")]),
+        expression_tree=deque([Constant(1)]),
+        comment=InlineComment("note"),
+    )
+    assert cl.comment == InlineComment("note")
+
+
+def test_expr_line_defaults():
+    el = ExprLine(expression_tree=deque([Constant(1)]))
+    assert el.return_expr is False
+    assert el.pars_nesting is False
+    assert el.type == "expr_line"
+
+
+# --- CommentLine.from_raw_comment ---------------------------------------
+
+def test_comment_line_strips_leading_hash_and_space():
+    assert CommentLine.from_raw_comment("# a plain note").content == "a plain note"
+
+
+def test_comment_line_strips_all_leading_hashes():
+    # lstrip("# ") removes any run of '#' and ' ' characters.
+    assert CommentLine.from_raw_comment("## heading").content == "heading"
+
+
+# --- MarkdownComment.from_raw_comment -----------------------------------
+
+def test_markdown_comment_single_hash():
+    assert MarkdownComment.from_raw_comment("# Title").content == "Title"
+
+
+def test_markdown_comment_double_hash_keeps_inner_hash():
+    # Regex `^#[ ]*(.+)` consumes only the first '#'; a heading written with
+    # '##' therefore keeps the second '#' in its content.
+    assert MarkdownComment.from_raw_comment("## A heading").content == "# A heading"
+
+
+# --- CommentCommand.from_raw_comment: kwarg vs flag ---------------------
+
+def test_comment_command_kwarg_style():
+    cc = CommentCommand.from_raw_comment("# hc: decimals=2")
+    assert cc.commands == {"decimals": 2}
+    assert cc.type == "comment_command"
+
+
+def test_comment_command_flag_style():
+    cc = CommentCommand.from_raw_comment("# hc: -f 2g")
+    assert cc.commands["format"] == "2g"
+    assert cc.commands["multiline"] is False
+
+
+# --- Import --------------------------------------------------------------
+
+def test_import_defaults():
+    imp = Import(names=deque([Name("math", None)]))
+    assert imp.import_from is False
+    assert imp.import_from_module is None
+    assert imp.type == "import"
+
+
+def test_import_from_fields():
+    imp = Import(
+        import_from=True,
+        import_from_module="math",
+        import_from_level=0,
+        names=deque([Name("sqrt", None)]),
+    )
+    assert imp.import_from is True
+    assert imp.import_from_module == "math"
+    assert imp.import_from_level == 0

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,0 +1,74 @@
+"""
+Layer-1 data-model tests for the primitive nodes in ``parsing/nodes.py``:
+field defaults, the ``type`` discriminant, equality, and the base
+``HcNode.render`` contract.
+"""
+from collections import deque
+
+import pytest
+
+from handcalcs.parsing.nodes import (
+    HcNode,
+    Name,
+    Constant,
+    Attribute,
+    List,
+    Tuple,
+    Set,
+    Dictionary,
+)
+from handcalcs.parsing.null_values import NoValue
+
+
+def test_hcnode_render_not_implemented():
+    with pytest.raises(NotImplementedError):
+        HcNode().render()
+
+
+def test_name_defaults():
+    n = Name("alpha")
+    assert n.identifier == "alpha"
+    assert n.value == NoValue()
+    assert n.type == "name"
+
+
+def test_name_with_value():
+    assert Name("alpha", 3).value == 3
+
+
+def test_constant_requires_value_and_has_type():
+    c = Constant(4)
+    assert c.value == 4
+    assert c.type == "constant"
+
+
+def test_attribute_defaults():
+    a = Attribute("obj", "attr")
+    assert a.namespace == "obj"
+    assert a.identifier == "attr"
+    assert a.value == NoValue()
+    assert a.type == "attribute"
+
+
+@pytest.mark.parametrize(
+    "cls,type_str",
+    [(List, "list"), (Tuple, "tuple"), (Set, "set")],
+    ids=["list", "tuple", "set"],
+)
+def test_sequence_collection_nodes(cls, type_str):
+    node = cls(deque([Constant(1), Constant(2)]))
+    assert node.elems == deque([Constant(1), Constant(2)])
+    assert node.type == type_str
+
+
+def test_dictionary_node():
+    d = Dictionary(deque([Constant(1)]), deque([Constant(2)]))
+    assert d.keys == deque([Constant(1)])
+    assert d.values == deque([Constant(2)])
+    assert d.type == "dictionary"
+
+
+def test_node_equality_is_structural():
+    assert Name("a", 1) == Name("a", 1)
+    assert Name("a", 1) != Name("a", 2)
+    assert Constant(1) != Name("a", 1)

--- a/tests/test_null_values.py
+++ b/tests/test_null_values.py
@@ -1,0 +1,41 @@
+"""
+Layer-1 tests for the sentinel value nodes in ``parsing/null_values.py``.
+"""
+import pytest
+
+from handcalcs.parsing.null_values import NoValue, HcNotImplemented
+
+
+def test_novalue_type_and_render():
+    nv = NoValue()
+    assert nv.type == "no_value"
+    assert nv.render() == ""
+
+
+def test_novalue_equality_between_instances():
+    assert NoValue() == NoValue()
+
+
+def test_novalue_not_equal_to_other_types():
+    assert (NoValue() == 5) is False
+    assert (NoValue() == "no_value") is False
+
+
+def test_novalue_ne_operator_behaves():
+    # NoValue defines a (misspelled, never-called) `__neq__`, but `!=` is
+    # correctly derived by Python from `__eq__`, so these hold regardless.
+    assert (NoValue() != NoValue()) is False
+    assert (NoValue() != 5) is True
+
+
+def test_novalue_is_frozen_and_hashable():
+    nv = NoValue()
+    with pytest.raises(Exception):
+        nv.type = "changed"  # frozen dataclass
+    assert isinstance(hash(nv), int)
+
+
+def test_hcnotimplemented_carries_node_name():
+    ni = HcNotImplemented(node_name="SomeNode")
+    assert ni.node_name == "SomeNode"
+    assert ni.type == "not_implemented"

--- a/tests/test_operator_nodes.py
+++ b/tests/test_operator_nodes.py
@@ -1,0 +1,85 @@
+"""
+Layer-1 data-model tests for arithmetic and comparison operator nodes:
+default ``symbol``/``pre``/``post`` and the ``type`` discriminant.
+"""
+import pytest
+
+from handcalcs.parsing.nodes import Constant
+from handcalcs.parsing.operator_nodes import (
+    HcBinOp,
+    PowOp,
+    DivOp,
+    FloorOp,
+    ModuloOp,
+    MultOp,
+    AddOp,
+    SubOp,
+    HcCompOp,
+    EqOp,
+    NeqOp,
+    GtOp,
+    GtEOp,
+    LtOp,
+    LtEOp,
+)
+
+
+@pytest.mark.parametrize(
+    "cls,symbol,type_str",
+    [
+        (PowOp, "**", "pow_op"),
+        (DivOp, "/", "div_op"),
+        (FloorOp, "//", "floor_op"),
+        (ModuloOp, "%", "modulo_op"),
+        (MultOp, "*", "mult_op"),
+        (AddOp, "+", "add_op"),
+        (SubOp, "-", "sub_op"),
+    ],
+    ids=["pow", "div", "floor", "modulo", "mult", "add", "sub"],
+)
+def test_binary_operator_defaults(cls, symbol, type_str):
+    node = cls(left=Constant(1), right=Constant(2))
+    assert node.left == Constant(1)
+    assert node.right == Constant(2)
+    assert node.symbol == symbol
+    assert node.type == type_str
+    assert node.pre == ""
+    assert node.post == ""
+
+
+def test_binary_operator_pre_post_settable():
+    node = AddOp(left=Constant(1), right=Constant(2), pre="(", post=")")
+    assert (node.pre, node.post) == ("(", ")")
+
+
+def test_binop_base_is_hcnode_subclass():
+    assert issubclass(AddOp, HcBinOp)
+
+
+@pytest.mark.parametrize(
+    "cls,symbol,type_str",
+    [
+        (EqOp, "==", "eq_op"),
+        (NeqOp, "!=", "neq_op"),
+        (GtOp, ">", "gt_op"),
+        (GtEOp, ">=", "gte_op"),
+        (LtOp, "<", "lt_op"),
+        (LtEOp, "<=", "lte_op"),
+    ],
+    ids=["eq", "neq", "gt", "gte", "lt", "lte"],
+)
+def test_comparison_operator_defaults(cls, symbol, type_str):
+    node = cls()
+    assert node.symbol == symbol
+    assert node.type == type_str
+
+
+def test_compop_base_is_hcnode_subclass():
+    assert issubclass(EqOp, HcCompOp)
+
+
+def test_comparison_operator_type_readable_on_class():
+    # The parser stores bare operator *classes* (not instances) in a Compare
+    # deque; the render handlers rely on `type`/`symbol` being class-readable.
+    assert GtOp.type == "gt_op"
+    assert GtOp.symbol == ">"

--- a/tests/test_render_nodes.py
+++ b/tests/test_render_nodes.py
@@ -231,12 +231,6 @@ def test_comment_command_renders_empty(renderer, make_context):
     assert renderer.render(node, make_context()) == ""
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="render_comment_command reassigns global_context via "
-    "RenderContext.__or__, which jams the merged dict into the `space` "
-    "positional instead of setting `decimals`; see the union bug.",
-)
 def test_comment_command_mutates_global_context(renderer, make_context):
     node = CommentCommand(commands={"decimals": 2})
     ctx = make_context()
@@ -327,25 +321,15 @@ def test_elif_block_no_true_clause_message(render):
 
 
 # ---------------------------------------------------------------------------
-# Documented bugs (xfail)
+# Previously-buggy paths, now fixed
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="toggle_param_line reads context.param_line with no default, so a "
-    "CalcLine cannot render from a clean context (AttributeError). This also "
-    "breaks the real HandCalcs pipeline on a plain calc line.",
-)
 def test_calc_line_renders_from_clean_context(render):
+    # A CalcLine as the very first rendered node (no param_line seeded) must
+    # render rather than raise; toggle_param_line now defaults param_line.
     assert render(_calc_c_equals_a_plus_2()) == "c = a+2 = 3+2 = 5\n"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="render_exprline sets current_mode on the throwaway `.current` "
-    "snapshot rather than the line context, so nested Name renders raise "
-    "ContextKeyError.",
-)
 def test_expr_line_rendering(render):
     node = ExprLine(
         expression_tree=deque([
@@ -356,23 +340,14 @@ def test_expr_line_rendering(render):
             )
         ])
     )
-    render(node, param_line=False)
+    # sym then num columns; __main__ namespace suppressed.
+    assert render(node, param_line=False) == " print(d)  =  print(4)  = "
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="render_markdown_comment returns node.comment, but MarkdownComment "
-    "has attribute `content`, raising AttributeError.",
-)
+
 def test_markdown_comment_rendering(render):
     assert render(MarkdownComment(content="A heading")) == "A heading"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="render_compare passes the RenderContext (context) rather than the "
-    "BaseRenderContext into the recursive render, so downstream handlers fail "
-    "on context.current (AttributeError).",
-)
 def test_compare_rendering(render):
     node = Compare(deque([Name("a", 3), GtOp, Constant(2)]))
     assert render(node, current_mode="sym") == "a>2"

--- a/tests/test_render_nodes.py
+++ b/tests/test_render_nodes.py
@@ -1,0 +1,378 @@
+"""
+Representative Layer-3 tests: render individual nodes through a bare
+``BaseRenderer`` and assert the produced string.
+
+This module demonstrates the parametrized pattern the full per-node matrix
+will follow (constants, names, collections, operators, comparisons, function
+calls, comments). Known bugs are pinned with ``xfail(strict=True)`` per the
+agreed policy so the suite documents them and flags a fix via an unexpected
+pass.
+"""
+from collections import deque
+
+import pytest
+
+from handcalcs.renderers.base import ContextKeyError, ContextValueError
+from handcalcs.parsing.nodes import Name, Constant, List, Tuple, Set, Dictionary
+from handcalcs.parsing.operator_nodes import (
+    AddOp,
+    SubOp,
+    MultOp,
+    DivOp,
+    PowOp,
+    FloorOp,
+    GtOp,
+    GtEOp,
+    LtOp,
+    LtEOp,
+    EqOp,
+    NeqOp,
+)
+from handcalcs.parsing.inline_nodes import (
+    FunctionCall,
+    Compare,
+    InlineComment,
+    InlineCommand,
+)
+from handcalcs.parsing.line_nodes import (
+    MarkdownComment,
+    CalcLine,
+    ExprLine,
+    Import,
+    CommentLine,
+    CommentCommand,
+)
+from handcalcs.parsing.block_nodes import IfBlock, ElseBlock, ElifBlock
+
+
+# ---------------------------------------------------------------------------
+# Constant
+# ---------------------------------------------------------------------------
+
+def test_constant_applies_format_code(render):
+    assert render(Constant(3.14159265), format_code=".3g") == "3.14"
+
+
+def test_constant_int(render):
+    assert render(Constant(4)) == "4"
+
+
+def test_constant_non_numeric_falls_back_to_str(render):
+    # A format code that does not apply to the value raises ValueError inside
+    # the handler and falls back to plain str().
+    assert render(Constant("foo")) == "foo"
+
+
+# ---------------------------------------------------------------------------
+# Name
+# ---------------------------------------------------------------------------
+
+def test_name_symbolic_mode_renders_identifier(render):
+    assert render(Name("alpha", 3), current_mode="sym") == "alpha"
+
+
+def test_name_numeric_mode_renders_formatted_value(render):
+    assert render(Name("alpha", 3), current_mode="num") == "3"
+
+
+def test_name_numeric_mode_applies_format_code(render):
+    assert render(Name("alpha", 3.14159), current_mode="num", format_code=".2f") == "3.14"
+
+
+def test_name_without_current_mode_raises(render):
+    with pytest.raises(ContextKeyError):
+        render(Name("a", 1))
+
+
+def test_name_unknown_mode_raises(render):
+    with pytest.raises(ContextValueError):
+        render(Name("a", 1), current_mode="bogus")
+
+
+# ---------------------------------------------------------------------------
+# Collections
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "node,expected",
+    [
+        (List(deque([Constant(1), Constant(2)])), "[1, 2]"),
+        (List(deque([])), "[]"),
+        (Set(deque([Constant(1)])), "{1}"),
+        (Tuple(deque([Constant(1), Constant(2)])), "(1, 2)"),
+        (Dictionary(deque([Constant(1)]), deque([Constant(2)])), "{1: 2}"),
+    ],
+    ids=["list", "empty-list", "set", "tuple", "dict"],
+)
+def test_collection_rendering(render, node, expected):
+    assert render(node) == expected
+
+
+# ---------------------------------------------------------------------------
+# Binary operators
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "node,expected",
+    [
+        (AddOp(left=Constant(1), right=Constant(2)), "1+2"),
+        (SubOp(left=Constant(1), right=Constant(2)), "1-2"),
+        (MultOp(left=Constant(1), right=Constant(2)), "1*2"),
+        (DivOp(left=Constant(1), right=Constant(2)), "1/2"),
+        (PowOp(left=Constant(1), right=Constant(2)), "1**2"),
+    ],
+    ids=["add", "sub", "mult", "div", "pow"],
+)
+def test_binary_operator_rendering(render, node, expected):
+    assert render(node) == expected
+
+
+def test_binary_operator_pre_and_post_wrap(render):
+    node = AddOp(left=Constant(1), right=Constant(2), pre="(", post=")")
+    assert render(node) == "(1+2)"
+
+
+def test_floor_op_has_no_handler_and_falls_back(render):
+    # FloorOp (and ModuloOp) are not registered in BaseRenderer; they hit
+    # render_unknown and stringify. Pinning current behavior; if a handler is
+    # added, update this test.
+    out = render(FloorOp(left=Constant(1), right=Constant(2)))
+    assert out.startswith("FloorOp(")
+
+
+# ---------------------------------------------------------------------------
+# Comparison operators
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "node,expected",
+    [
+        (GtOp(), ">"),
+        (GtEOp(), ">="),
+        (LtOp(), "<"),
+        (LtEOp(), "<="),
+        (EqOp(), "=="),
+        (NeqOp(), "!="),
+    ],
+    ids=["gt", "gte", "lt", "lte", "eq", "neq"],
+)
+def test_comparison_operator_symbols(render, node, expected):
+    assert render(node, current_mode="sym") == expected
+
+
+# ---------------------------------------------------------------------------
+# FunctionCall
+# ---------------------------------------------------------------------------
+
+def test_function_call_suppresses_main_namespace(render):
+    node = FunctionCall(
+        namespace=Name("__main__", "__main__"),
+        function_name=Name("sin", "sin"),
+        args=deque([Constant(2)]),
+    )
+    assert render(node, current_mode="sym") == " sin(2) "
+
+
+def test_function_call_with_namespace(render):
+    node = FunctionCall(
+        namespace=Name("math", "math"),
+        function_name=Name("sin", "sin"),
+        args=deque([Constant(2)]),
+    )
+    assert render(node, current_mode="sym") == " math.sin(2) "
+
+
+# ---------------------------------------------------------------------------
+# InlineComment
+# ---------------------------------------------------------------------------
+
+def test_inline_comment_rendering(render):
+    assert render(InlineComment("a note")) == " (a note)"
+
+
+# ---------------------------------------------------------------------------
+# Import
+# ---------------------------------------------------------------------------
+
+def test_import_plain(render):
+    node = Import(names=deque([Name("math", None)]))
+    assert render(node) == "[Python import]: import math\n\n"
+
+
+def test_import_from_module(render):
+    node = Import(
+        import_from=True,
+        import_from_module="math",
+        import_from_level=0,
+        names=deque([Name("sqrt", None), Name("pi", None)]),
+    )
+    assert render(node) == "[Python import]: from math import sqrt, pi\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Comment nodes
+# ---------------------------------------------------------------------------
+
+def test_comment_line_appends_newline(render):
+    assert render(CommentLine(content="a note")) == "a note\n"
+
+
+def test_inline_command_mutates_line_context_and_renders_empty(renderer, make_context):
+    node = InlineCommand(content="hc: precision=3", commands={"precision": 3})
+    ctx = make_context()
+    assert renderer.render(node, ctx) == ""
+    assert ctx.line_context.precision == 3
+
+
+def test_comment_command_renders_empty(renderer, make_context):
+    # The command node itself renders to an empty string (its effect is on the
+    # context, verified separately below).
+    node = CommentCommand(commands={"decimals": 2})
+    assert renderer.render(node, make_context()) == ""
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="render_comment_command reassigns global_context via "
+    "RenderContext.__or__, which jams the merged dict into the `space` "
+    "positional instead of setting `decimals`; see the union bug.",
+)
+def test_comment_command_mutates_global_context(renderer, make_context):
+    node = CommentCommand(commands={"decimals": 2})
+    ctx = make_context()
+    renderer.render(node, ctx)
+    assert ctx.global_context.decimals == 2
+
+
+# ---------------------------------------------------------------------------
+# CalcLine
+#
+# NOTE: CalcLine rendering requires `param_line` to be seeded on the context.
+# From a clean/default context the `toggle_param_line` sym-rule raises (see the
+# clean-context xfail below); these tests seed it to exercise the render logic.
+# ---------------------------------------------------------------------------
+
+def _calc_c_equals_a_plus_2():
+    return CalcLine(
+        assigns=deque([Name("c", 5)]),
+        expression_tree=deque([AddOp(left=Name("a", 3), right=Constant(2))]),
+    )
+
+
+def test_calc_line_full_mode(render):
+    assert render(_calc_c_equals_a_plus_2(), param_line=False) == "c = a+2 = 3+2 = 5\n"
+
+
+def test_calc_line_symbolic_only_mode(render):
+    # Current behavior: assigns and result columns are omitted; a leading
+    # " = " prefix remains. Pinned as-is.
+    assert render(_calc_c_equals_a_plus_2(), param_line=False, mode="sym") == " = a+2\n"
+
+
+def test_calc_line_numeric_only_mode(render):
+    assert render(_calc_c_equals_a_plus_2(), param_line=False, mode="num") == " = 3+2\n"
+
+
+def test_calc_line_param_line_single_constant(render):
+    node = CalcLine(assigns=deque([Name("a", 2)]), expression_tree=deque([Constant(2)]))
+    assert render(node, param_line=False) == "a = 2\n"
+
+
+def test_calc_line_ignore_short_circuits(render):
+    assert render(_calc_c_equals_a_plus_2(), param_line=False, ignore=True) == ""
+
+
+# ---------------------------------------------------------------------------
+# Blocks
+# ---------------------------------------------------------------------------
+
+def test_if_block_renders_header_and_lines(render):
+    param = CalcLine(assigns=deque([Name("a", 2)]), expression_tree=deque([Constant(2)]))
+    node = IfBlock(
+        lines=deque([param]),
+        test=Compare(deque([Constant(2), LtEOp, Name("a", 3), LtOp, Constant(5)])),
+        is_true=True,
+    )
+    assert render(node, param_line=False) == "Since (2<=a<5) -> (2<=3<5) is True:\na = 2\n"
+
+
+def test_elif_block_selects_true_clause(render):
+    winner = IfBlock(
+        lines=deque([CalcLine(assigns=deque([Name("d", 5)]), expression_tree=deque([Constant(5)]))]),
+        test=Compare(deque([Name("a", 3), GtOp, Constant(2)])),
+        is_true=True,
+    )
+    loser = IfBlock(
+        lines=deque([CalcLine(assigns=deque([Name("d", 6)]), expression_tree=deque([Constant(6)]))]),
+        test=Compare(deque([Name("a", 3), GtOp, Constant(9)])),
+        is_true=False,
+    )
+    node = ElifBlock(lines=deque([loser, winner]))
+    out = render(node, param_line=False)
+    assert "is True:" in out
+    assert "d = 5" in out
+    assert "d = 6" not in out
+
+
+def test_elif_block_no_true_clause_message(render):
+    loser = IfBlock(
+        lines=deque([CalcLine(assigns=deque([Name("d", 6)]), expression_tree=deque([Constant(6)]))]),
+        test=Compare(deque([Name("a", 3), GtOp, Constant(9)])),
+        is_true=False,
+    )
+    node = ElifBlock(lines=deque([loser]))
+    assert render(node, param_line=False) == (
+        "No conditions were satisfied within the if-elif block"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Documented bugs (xfail)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="toggle_param_line reads context.param_line with no default, so a "
+    "CalcLine cannot render from a clean context (AttributeError). This also "
+    "breaks the real HandCalcs pipeline on a plain calc line.",
+)
+def test_calc_line_renders_from_clean_context(render):
+    assert render(_calc_c_equals_a_plus_2()) == "c = a+2 = 3+2 = 5\n"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="render_exprline sets current_mode on the throwaway `.current` "
+    "snapshot rather than the line context, so nested Name renders raise "
+    "ContextKeyError.",
+)
+def test_expr_line_rendering(render):
+    node = ExprLine(
+        expression_tree=deque([
+            FunctionCall(
+                namespace=Name("__main__", "__main__"),
+                function_name=Name("print", "print"),
+                args=deque([Name("d", 4)]),
+            )
+        ])
+    )
+    render(node, param_line=False)
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="render_markdown_comment returns node.comment, but MarkdownComment "
+    "has attribute `content`, raising AttributeError.",
+)
+def test_markdown_comment_rendering(render):
+    assert render(MarkdownComment(content="A heading")) == "A heading"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="render_compare passes the RenderContext (context) rather than the "
+    "BaseRenderContext into the recursive render, so downstream handlers fail "
+    "on context.current (AttributeError).",
+)
+def test_compare_rendering(render):
+    node = Compare(deque([Name("a", 3), GtOp, Constant(2)]))
+    assert render(node, current_mode="sym") == "a>2"

--- a/tests/test_render_nodes.py
+++ b/tests/test_render_nodes.py
@@ -277,6 +277,46 @@ def test_calc_line_ignore_short_circuits(render):
 
 
 # ---------------------------------------------------------------------------
+# ExprLine (bare expression statements: no assignment, so no result column)
+# ---------------------------------------------------------------------------
+
+def test_expr_line_statement_call_shows_symbolic_and_numeric(render):
+    # A statement call renders `sym = num` (substitution view), with no
+    # trailing equals and no fabricated result.
+    node = ExprLine(
+        expression_tree=deque([
+            FunctionCall(
+                namespace=Name("__main__", "__main__"),
+                function_name=Name("print", "print"),
+                args=deque([Name("d", 4)]),
+            )
+        ])
+    )
+    assert render(node) == " print(d)  =  print(4) \n"
+
+
+def test_expr_line_value_bearing_expression(render):
+    node = ExprLine(expression_tree=deque([AddOp(left=Name("x", 10), right=Name("y", 20))]))
+    assert render(node) == "x+y = 10+20\n"
+
+
+def test_expr_line_return_is_symbolic_only(render):
+    # A return statement lives in a symbolic function definition: symbolic form
+    # only, no numeric substitution (its names have no runtime value).
+    node = ExprLine(
+        expression_tree=deque([AddOp(left=Name("pi"), right=Constant(1))]),
+        return_expr=True,
+    )
+    assert render(node) == "pi+1\n"
+
+
+def test_expr_line_docstring_renders_as_plain_line(render):
+    # A bare string statement parses to a single Constant holding the string.
+    node = ExprLine(expression_tree=deque([Constant("Module note.")]))
+    assert render(node) == "Module note.\n"
+
+
+# ---------------------------------------------------------------------------
 # Blocks
 # ---------------------------------------------------------------------------
 
@@ -288,6 +328,21 @@ def test_if_block_renders_header_and_lines(render):
         is_true=True,
     )
     assert render(node, param_line=False) == "Since (2<=a<5) -> (2<=3<5) is True:\na = 2\n"
+
+
+def test_if_block_multiple_lines_single_newlines(render):
+    # Rendered lines self-terminate; the block must not double-space them.
+    node = IfBlock(
+        lines=deque([
+            CalcLine(assigns=deque([Name("a", 2)]), expression_tree=deque([Constant(2)])),
+            CalcLine(assigns=deque([Name("b", 3)]), expression_tree=deque([Constant(3)])),
+        ]),
+        test=Compare(deque([Name("a", 3), GtOp, Constant(2)])),
+        is_true=True,
+    )
+    assert render(node, param_line=False) == (
+        "Since (a>2) -> (3>2) is True:\na = 2\nb = 3\n"
+    )
 
 
 def test_elif_block_selects_true_clause(render):
@@ -328,20 +383,6 @@ def test_calc_line_renders_from_clean_context(render):
     # A CalcLine as the very first rendered node (no param_line seeded) must
     # render rather than raise; toggle_param_line now defaults param_line.
     assert render(_calc_c_equals_a_plus_2()) == "c = a+2 = 3+2 = 5\n"
-
-
-def test_expr_line_rendering(render):
-    node = ExprLine(
-        expression_tree=deque([
-            FunctionCall(
-                namespace=Name("__main__", "__main__"),
-                function_name=Name("print", "print"),
-                args=deque([Name("d", 4)]),
-            )
-        ])
-    )
-    # sym then num columns; __main__ namespace suppressed.
-    assert render(node, param_line=False) == " print(d)  =  print(4)  = "
 
 
 def test_markdown_comment_rendering(render):

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,0 +1,75 @@
+"""
+Layer-1 tests for ``HcSequence`` (the root node) and the free helper
+functions in ``parsing/sequence.py``: tree flattening, if-tree conversion,
+level assignment, and the ``from_source`` factory.
+
+The exhaustive nested-block shape produced by ``from_source`` is already
+asserted by ``test_parser.py::test_hcsequence``; here we cover the smaller
+units and invariants without duplicating that large fixture.
+"""
+from collections import deque
+
+import pytest
+
+from handcalcs.parsing.sequence import (
+    HcSequence,
+    flatten,
+    flatten_deque,
+    convert_if_tree,
+    set_level,
+)
+from handcalcs.parsing.block_nodes import IfBlock, ElifBlock, ForBlock
+from handcalcs.parsing.line_nodes import CalcLine
+from handcalcs.parsing.nodes import Name, Constant
+
+
+def test_flatten_recurses_nested_deques():
+    nested = deque([1, deque([2, deque([3]), 4]), 5])
+    assert list(flatten(nested)) == [1, 2, 3, 4, 5]
+
+
+def test_flatten_deque_returns_deque():
+    result = flatten_deque(deque([1, deque([2, 3])]))
+    assert result == deque([1, 2, 3])
+    assert isinstance(result, deque)
+
+
+def test_convert_if_tree_wraps_ifblock_as_elifblock():
+    ib = IfBlock(lines=deque([]), test=deque([]), orelse=deque([]))
+    assert isinstance(convert_if_tree(ib), ElifBlock)
+
+
+def test_convert_if_tree_passes_through_non_ifblock():
+    fb = ForBlock(lines=deque([]))
+    assert convert_if_tree(fb) is fb
+
+
+def test_set_level_mutates_and_returns_node():
+    cl = CalcLine(assigns=deque([Name("a")]), expression_tree=deque([Constant(1)]))
+    returned = set_level(cl, 3)
+    assert returned is cl
+    assert cl.level == 3
+
+
+def test_from_source_stores_globals_and_locals():
+    seq = HcSequence.from_source("a = 1\n", {"a": 1}, {})
+    assert seq.type == "root"
+    assert seq.hc_globals == {"a": 1}
+    assert seq.hc_locals == {}
+
+
+def test_from_source_converts_top_level_if_to_elif_block():
+    source = "a = 2\nif a > 1:\n    b = 3\n"
+    seq = HcSequence.from_source(source, {"a": 2, "b": 3}, {})
+    kinds = [type(node).__name__ for node in seq.sequence]
+    assert kinds == ["CalcLine", "ElifBlock"]
+
+
+def test_from_source_assigns_nesting_levels():
+    source = "a = 2\nif a > 1:\n    b = 3\n"
+    seq = HcSequence.from_source(source, {"a": 2, "b": 3}, {})
+    elif_block = seq.sequence[-1]
+    inner_if = elif_block.lines[0]
+    # The CalcLine nested one block deep is at level 1.
+    nested_calc = inner_if.lines[0]
+    assert nested_calc.level == 1


### PR DESCRIPTION
## Summary

Adds broad unit-test coverage for the handcalcs v2 core (parsing nodes + `BaseRenderer`), fixes six latent `BaseRenderer` bugs those tests surfaced, and reworks `ExprLine` rendering so bare expression statements render coherently. **Whole suite: 141 passed.**

Three commits, each building on the last:

### 1. `test:` unit tests for parsing nodes and BaseRenderer
- `tests/conftest.py`: isolated-render scaffolding (`renderer` / `make_context` / `render` fixtures). The `render` helper places overrides on the *line* context because `BaseRenderContext.current` overlays line-over-global via `ChainMap` and an "empty" `RenderContext()` is fully populated with defaults.
- Layer 1 (data model): `test_nodes`, `test_operator_nodes`, `test_inline_nodes`, `test_line_nodes`, `test_block_nodes`, `test_null_values`, `test_sequence` — field defaults, `type` discriminants, equality, the branching constructors (`from_raw_comment`, `from_if_tree`), and sequence helpers.
- Layer 2 (machinery): `test_base_renderer` — dispatch, class-vs-instance registry isolation, classifier routing, context layering, rule pipelines.
- Layer 3 (rendering): `test_render_nodes` — constants, names, collections, operators, comparisons, function calls, imports, comments, CalcLine modes, if/elif blocks.

### 2. `fix:` repair six BaseRenderer bugs + convert placeholder tests
Bugs the tests documented (originally pinned as `xfail`, now real passing assertions):
1. `RenderContext.__or__` jammed the merged dict into the `space` positional → context corruption. Now unpacks with `**`.
2. `render_root` iterated the pre/post dicts by **key** → `TypeError`. Now `.values()`.
3. `render_node` read **class-level** rule dicts, ignoring instance-registered rules. Now uses `_symbolic_rules`/`_numeric_rules`.
4. `render_compare` passed the `.current` snapshot into recursion (and shadowed `node`) → `AttributeError`.
5. `render_markdown_comment` read non-existent `.comment` → `AttributeError`. Now `.content`.
6. `toggle_param_line` read `context.param_line` with no default (crashed a leading `CalcLine`, **and the real pipeline** on any script whose first statement is a plain calc); `render_exprline` set `current_mode` on a throwaway snapshot.

Also converts the two `test_handcalcs.py` placeholders (`print` + `assert False`) into real end-to-end smoke tests.

### 3. `feat:` classify and render ExprLine coherently (interim, no result capture)
A bare expression statement has no assignment target, so there is no result column. `render_exprline` now classifies the three kinds and renders each honestly (no dangling `=`, no fabricated result):
- **docstring / bare string** → plain line (previously crashed, then rendered `note = note`)
- **return statement** → symbolic only (def-body names have no runtime value)
- **ordinary statement/expr** → `sym = num`, no trailing `=`

`ExprLine` now self-terminates with a newline like `CalcLine`; `render_if_block` consequently concatenates its already-terminated lines, fixing a latent double-spacing of multi-line blocks. The parser's `ast.Expr` branch is simplified to drop the `Doc string: {repr}` interpolation while keeping the deque-wrapped `expression_tree` contract.

## Deferred / follow-ups (out of scope here)
- **ExprLine result capture** — the "temp variable" idea. The correct home is capturing values during the single `exec` at `handcalcs.py:35` (never per-line re-eval, which double-runs side effects). Additive next step: an `ExprLine.value` field + a fourth "result" branch.
- Cosmetic: `render_exprline`'s statement-call form keeps numeric substitution (`print(d) = print(4)`); switching bare side-effect calls to symbolic-only is a one-line change if preferred.

## Test plan
- [x] `pytest tests/` → 141 passed
- [x] End-to-end pipeline spot-checked (docstrings, statement calls, value-bearing exprs, nested if/elif/else, block spacing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)